### PR TITLE
Save resolved kwargs to class

### DIFF
--- a/src/unittest_templates/api.py
+++ b/src/unittest_templates/api.py
@@ -24,9 +24,9 @@ class GenericTestCase(Generic[T], unittest.TestCase):
     def setUp(self) -> None:
         """Set up the generic testing method."""
         self.pre_setup_hook()
-        kwargs = self.kwargs or {}
-        kwargs = self._pre_instantiation_hook(kwargs=dict(kwargs))
-        self.instance = self.cls(**kwargs)  # type: ignore
+        kwargs = dict(self.kwargs or {})
+        self.kwargs = self._pre_instantiation_hook(kwargs=kwargs)
+        self.instance = self.cls(**self.kwargs)  # type: ignore
         self.post_instantiation_hook()
 
     def pre_setup_hook(self) -> None:

--- a/src/unittest_templates/api.py
+++ b/src/unittest_templates/api.py
@@ -25,8 +25,8 @@ class GenericTestCase(Generic[T], unittest.TestCase):
         """Set up the generic testing method."""
         self.pre_setup_hook()
         kwargs = dict(self.kwargs or {})
-        self.kwargs = self._pre_instantiation_hook(kwargs=kwargs)
-        self.instance = self.cls(**self.kwargs)  # type: ignore
+        self.instance_kwargs = self._pre_instantiation_hook(kwargs=kwargs)
+        self.instance = self.cls(**self.instance_kwargs)  # type: ignore
         self.post_instantiation_hook()
 
     def pre_setup_hook(self) -> None:

--- a/src/unittest_templates/api.py
+++ b/src/unittest_templates/api.py
@@ -24,8 +24,8 @@ class GenericTestCase(Generic[T], unittest.TestCase):
     def setUp(self) -> None:
         """Set up the generic testing method."""
         self.pre_setup_hook()
-        kwargs = dict(self.kwargs or {})
-        self.instance_kwargs = self._pre_instantiation_hook(kwargs=kwargs)
+        kwargs = self.kwargs or {}
+        self.instance_kwargs = self._pre_instantiation_hook(kwargs=dict(kwargs))
         self.instance = self.cls(**self.instance_kwargs)  # type: ignore
         self.post_instantiation_hook()
 


### PR DESCRIPTION
This PR stores the resolved `kwargs` in an attribute to allow access to them.